### PR TITLE
Stop existing actions when new commits are pushed

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,9 +9,8 @@ on:
 
 # Add concurrency to cancel in-progress jobs when a new commit is pushed to the PR
 concurrency:
-  # Use the workflow name and PR number (or branch name for non-PR events) as the concurrency group
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # Cancel in-progress runs when a new workflow with the same concurrency group is queued
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 # Add concurrency to cancel in-progress jobs when a new commit is pushed to the PR
-# This avoids CI jobs "staking up" for the same PR
+# This avoids CI jobs "stacking up" for the same PR
 concurrency:
   # Cancel in-progress runs when a new workflow with the same concurrency group is queued
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,6 +7,13 @@ on:
     types: [ synchronize, opened ]
   workflow_dispatch:
 
+# Add concurrency to cancel in-progress jobs when a new commit is pushed to the PR
+concurrency:
+  # Use the workflow name and PR number (or branch name for non-PR events) as the concurrency group
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs when a new workflow with the same concurrency group is queued
+  cancel-in-progress: true
+
 env:
   OPENSTUDIO_VER: 3.9.0
   OPENSTUDIO_SHA: c77fbb9569

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 # Add concurrency to cancel in-progress jobs when a new commit is pushed to the PR
+# This avoids CI jobs "staking up" for the same PR
 concurrency:
   # Cancel in-progress runs when a new workflow with the same concurrency group is queued
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Pull Request Description
When new commits are pushed to a PR, all previous in-progress actions are stopped and only the new one will run.

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run