### PR TITLE
Use HPXML class in ResStockArgumentsPostHPXML measure

### DIFF
--- a/measures/ResStockArgumentsPostHPXML/measure.rb
+++ b/measures/ResStockArgumentsPostHPXML/measure.rb
@@ -100,71 +100,67 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
     max_random_shift_steps = (args[:flex_random_shift_minutes] / @minutes_per_step).to_i
     @random_shift_steps = @prng.rand(-max_random_shift_steps..max_random_shift_steps)
 
-    # Parse the HPXML document
-    doc = XMLHelper.parse_file(@hpxml_path)
-    hpxml_doc = XMLHelper.get_element(doc, '/HPXML')
-    doc_buildings = XMLHelper.get_elements(hpxml_doc, 'Building')
-
     # Process each building
-    doc_buildings.each_with_index do |building, index|
-      hpxml_bldg = @hpxml.buildings[index]
+    @hpxml.buildings.each_with_index do |hpxml_bldg, index|
       if hpxml_bldg.hvac_controls.to_a.length != 0 && !skip_hvac_flexibility?(args)
         hvac_schedule = create_hvac_schedule(index)
-        modified_schedule = modify_hvac_schedule(index, hvac_schedule)
-        write_schedule(modified_schedule, building, index, output_csv_path)
+        modified_schedule = modify_hvac_schedule(hpxml_bldg, hvac_schedule)
+        write_schedule(modified_schedule, hpxml_bldg, index, output_csv_path)
       end
-      if !skip_ev_flexibility?(args)
-        ev_schedule = get_ev_schedule(building)
-        next if ev_schedule.nil?
-        modified_ev_schedule = modify_ev_schedule(index, ev_schedule)
-        write_schedule(modified_ev_schedule, building, index, output_csv_path)
-      end
+      next unless !skip_ev_flexibility?(args)
+
+      ev_schedule = get_ev_schedule(hpxml_bldg)
+      next if ev_schedule.nil?
+
+      modified_ev_schedule = modify_ev_schedule(hpxml_bldg, ev_schedule)
+      write_schedule(modified_ev_schedule, hpxml_bldg, index, output_csv_path)
     end
 
     # Write out the modified hpxml
-    XMLHelper.write_file(doc, @hpxml_path)
+    XMLHelper.write_file(@hpxml.to_doc(), @hpxml_path)
     runner.registerInfo("Wrote file: #{@hpxml_path} with modified schedules.")
-    true
+    return true
   end
 
   # Determines if the post-processing step for HPXML should be skipped
   def skip_post_hpxml?(args)
-    skip_hvac_flexibility?(args) && skip_ev_flexibility?(args)
+    return skip_hvac_flexibility?(args) && skip_ev_flexibility?(args)
   end
 
   # Determines if HVAC flexibility modifications should be skipped
   # Skips if both peak offset and pre-peak duration are set to 0
   def skip_hvac_flexibility?(args)
-    true if args[:hvac_flex_peak_offset] == 0 && args[:hvac_flex_pre_peak_duration_hours] == 0
+    return true if args[:hvac_flex_peak_offset] == 0 && args[:hvac_flex_pre_peak_duration_hours] == 0
   end
 
   def skip_ev_flexibility?(args)
-    true if !args[:ev_flex_enabled]
+    return true if !args[:ev_flex_enabled]
   end
 
-  def get_ev_schedule(building)
-    schedule_file = get_existing_schedule_filepath(building)
-    return nil if schedule_file.nil?
+  def get_ev_schedule(hpxml_bldg)
+    schedule_file = get_existing_schedule_filepath(hpxml_bldg)
+    return if schedule_file.nil?
+
     schedule = CSV.read(schedule_file, headers: true)
     ev_schedule = {}
-    ev_column = "electric_vehicle"
-    return nil unless schedule.headers.include?(ev_column)
+    ev_column = 'electric_vehicle'
+    return unless schedule.headers.include?(ev_column)
+
     ev_schedule[ev_column.to_sym] = schedule[ev_column].map(&:to_f)
-    ev_schedule
+    return ev_schedule
   end
 
   # Generates the HVAC schedule for a given building index
   def create_hvac_schedule(building_index)
     generator = HVACScheduleGenerator.new(@hpxml, @hpxml_path, @runner, building_index)
-    generator.get_heating_cooling_setpoint_schedule
+    return generator.get_heating_cooling_setpoint_schedule
   end
 
-  # Retrieves an appropriate schedule modifier for a given building index
-  def get_schedule_modifier(building_index, modifier_class)
+  # Retrieves an appropriate schedule modifier for a given building
+  def get_schedule_modifier(hpxml_bldg, modifier_class)
     # Ensure the provided class is a subclass of ScheduleModifier
     raise ArgumentError, "#{modifier_class} must be a subclass of ScheduleModifier" unless modifier_class < ScheduleModifier
 
-    hpxml_bldg = @hpxml.buildings[building_index]
     state = hpxml_bldg.state_code
     sim_year = @hpxml.header.sim_calendar_year
     epw_path = Location.get_epw_path(hpxml_bldg, @hpxml_path)
@@ -177,18 +173,18 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
                            dst_end_day: hpxml_bldg.dst_end_day)
 
     # Create and return the modifier instance
-    modifier_class.new(state: state,
-                       sim_year: sim_year,
-                       weather: weather,
-                       epw_path: epw_path,
-                       minutes_per_step: @minutes_per_step,
-                       runner: @runner,
-                       dst_info: dst_info)
+    return modifier_class.new(state: state,
+                              sim_year: sim_year,
+                              weather: weather,
+                              epw_path: epw_path,
+                              minutes_per_step: @minutes_per_step,
+                              runner: @runner,
+                              dst_info: dst_info)
   end
 
   # Modifies the HVAC schedule based on flexibility inputs
-  def modify_hvac_schedule(building_index, schedule)
-    hvac_schedule_modifier = get_schedule_modifier(building_index, HVACScheduleModifier)
+  def modify_hvac_schedule(hpxml_bldg, schedule)
+    hvac_schedule_modifier = get_schedule_modifier(hpxml_bldg, HVACScheduleModifier)
 
     # Define flexibility inputs
     hvac_flexibility_inputs = FlexibilityInputs.new(
@@ -199,11 +195,11 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
     )
 
     # Apply modifications to the schedule
-    hvac_schedule_modifier.modify_shedule(schedule, hvac_flexibility_inputs)
+    return hvac_schedule_modifier.modify_shedule(schedule, hvac_flexibility_inputs)
   end
 
-  def modify_ev_schedule(building_index, schedule)
-    ev_schedule_modifier = get_schedule_modifier(building_index, EVScheduleModifier)
+  def modify_ev_schedule(hpxml_bldg, schedule)
+    ev_schedule_modifier = get_schedule_modifier(hpxml_bldg, EVScheduleModifier)
     ev_flexibility_inputs = FlexibilityInputs.new(
       peak_offset: 0,
       # Use hvac_flex_pre_peak_duration_hours so that shift/shed is the same as HVAC
@@ -211,12 +207,12 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
       pre_peak_offset: 0,
       random_shift_steps: @random_shift_steps
     )
-    ev_schedule_modifier.modify_schedule(schedule, ev_flexibility_inputs)
+    return ev_schedule_modifier.modify_schedule(schedule, ev_flexibility_inputs)
   end
 
   # Writes the HVAC schedule to a CSV file
-  def write_schedule(schedule, building, index, output_csv_path)
-    schedule_file = get_existing_schedule_filepath(building)
+  def write_schedule(schedule, hpxml_bldg, index, output_csv_path)
+    schedule_file = get_existing_schedule_filepath(hpxml_bldg)
 
     if schedule_file.nil?
       # Create a new schedule file if one does not exist
@@ -230,7 +226,7 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
           csv << row
         end
       end
-      update_hpxml_schedule_filepath(building, schedule_file)
+      hpxml_bldg.header.schedules_filepaths << schedule_file
     else
       # Process existing schedule file and update values
       data = CSV.read(schedule_file, headers: true)
@@ -259,27 +255,19 @@ class ResStockArgumentsPostHPXML < OpenStudio::Measure::ModelMeasure
       end
     end
 
-    schedule_file
+    return schedule_file
   end
 
   # Retrieves the existing schedule file path from the HPXML file
-  def get_existing_schedule_filepath(building)
-    building_extension = XMLHelper.create_elements_as_needed(building, %w[BuildingDetails BuildingSummary extension])
-    existing_schedules_filepaths = XMLHelper.get_values(building_extension, 'SchedulesFilePath', :string)
-    schedule_file = existing_schedules_filepaths.first
+  def get_existing_schedule_filepath(hpxml_bldg)
+    schedule_file = hpxml_bldg.header.schedules_filepaths.first
     return if schedule_file.nil?
 
     # Ensure the path is absolute
     if !Pathname.new(schedule_file).absolute?
       schedule_file = File.join(File.dirname(@hpxml_path), schedule_file)
     end
-    schedule_file
-  end
-
-  # Updates the HPXML file with the new schedule file path
-  def update_hpxml_schedule_filepath(building, new_schedule_filepath)
-    building_extension = XMLHelper.create_elements_as_needed(building, %w[BuildingDetails BuildingSummary extension])
-    XMLHelper.add_element(building_extension, 'SchedulesFilePath', new_schedule_filepath, :string)
+    return schedule_file
   end
 end
 

--- a/measures/ResStockArgumentsPostHPXML/measure.xml
+++ b/measures/ResStockArgumentsPostHPXML/measure.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <measure>
   <schema_version>3.1</schema_version>
+  <error></error>
   <name>res_stock_arguments_post_hpxml</name>
   <uid>db102ce5-ac96-4ef9-90d3-abbe53478716</uid>
-  <version_id>af53ca34-177b-43f8-946c-b9ae88a896de</version_id>
-  <version_modified>2025-04-02T22:42:00Z</version_modified>
+  <version_id>498f2709-670e-44be-b35f-9d78a36dc841</version_id>
+  <version_modified>2025-04-21T17:09:55Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>ResStockArgumentsPostHPXML</class_name>
   <display_name>ResStock Arguments Post-HPXML</display_name>
@@ -86,7 +87,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8FA012C5</checksum>
+      <checksum>4D34E2BF</checksum>
     </file>
     <file>
       <filename>common/README.md</filename>
@@ -113,6 +114,12 @@
       <checksum>055326E7</checksum>
     </file>
     <file>
+      <filename>ev_flexibility/ev_schedule_modifier.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>632986B4</checksum>
+    </file>
+    <file>
       <filename>hvac_flexibility/detailed_schedule_generator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -134,13 +141,13 @@
       <filename>test_resstock_arguments_post_hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>0A84481E</checksum>
+      <checksum>A4CE490F</checksum>
     </file>
     <file>
       <filename>test_template.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B71A1941</checksum>
+      <checksum>4719AE8A</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResStockArgumentsPostHPXML/resources/ev_flexibility/ev_schedule_modifier.rb
+++ b/measures/ResStockArgumentsPostHPXML/resources/ev_flexibility/ev_schedule_modifier.rb
@@ -12,9 +12,7 @@ Dir["#{File.dirname(__FILE__)}/../../../../resources/hpxml-measures/HPXMLtoOpenS
   require resource_file
 end
 
-
 class EVScheduleModifier < ScheduleModifier
-
   # Modifies the EV charging schedule based on flexibility inputs
   # Charging (positive values) is set to 0 during identified peak hours.
   # @param ev_schedule [Hash] Hash containing :electric_vehicle key with an array of charging values (+ve is charging, -ve is discharging)
@@ -28,13 +26,13 @@ class EVScheduleModifier < ScheduleModifier
     peak_period = Array.new(total_indices, 0)
     total_indices.times do |index|
       offset_times = _get_peak_times(index, flexibility_inputs)
-      index_in_day = index % (24 * @num_timesteps_per_hour)   
+      index_in_day = index % (24 * @num_timesteps_per_hour)
       # Check if current time is within peak period
-      if offset_times.peak_start_index <= index_in_day && index_in_day < offset_times.peak_end_index
-        peak_period[index] = 1
-        if modified_schedule[index] > 0  # if charging, set to 0
-          modified_schedule[index] = 0
-        end
+      next unless offset_times.peak_start_index <= index_in_day && index_in_day < offset_times.peak_end_index
+
+      peak_period[index] = 1
+      if modified_schedule[index] > 0  # if charging, set to 0
+        modified_schedule[index] = 0
       end
     end
     return {
@@ -49,5 +47,4 @@ class EVScheduleModifier < ScheduleModifier
     @runner.registerInfo('Modifying EV schedule ...')
     @runner.registerInfo("random_shift_steps=#{inputs.random_shift_steps}")
   end
-
 end

--- a/measures/ResStockArgumentsPostHPXML/tests/test_resstock_arguments_post_hpxml.rb
+++ b/measures/ResStockArgumentsPostHPXML/tests/test_resstock_arguments_post_hpxml.rb
@@ -43,6 +43,7 @@ class ResStockArgumentsPostHPXMLTest < Minitest::Test
       FileUtils.rm_rf(File.join(curdir, 'run'))
     end
   end
+
   def test_ev_load_flexibility_measure
     puts 'Testing EV Load Flexibility'
     # Define test parameters
@@ -74,6 +75,7 @@ class ResStockArgumentsPostHPXMLTest < Minitest::Test
       FileUtils.rm_rf(File.join(curdir, 'run'))
     end
   end
+
   def test_combined_hvac_and_ev_flexibility
     puts 'Testing Combined HVAC and EV Load Flexibility'
 
@@ -251,7 +253,7 @@ class ResStockArgumentsPostHPXMLTest < Minitest::Test
         assert_equal(summer_cooling_setpoint_base, cooling_setpoint)
         assert_equal(summer_heating_setpoint_base, heating_setpoint)
       elsif value == 'pre_peak'
-        assert_equal(summer_cooling_setpoint_base, cooling_setpoint)  # No precooling because daily avg temp is 63.4F
+        assert_equal(summer_cooling_setpoint_base, cooling_setpoint) # No precooling because daily avg temp is 63.4F
         assert_equal(summer_heating_setpoint_base, heating_setpoint)
       elsif value == 'peak'
         assert_equal(summer_cooling_setpoint_base + 2, cooling_setpoint)

--- a/resources/hpxml-measures/.rubocop.yml
+++ b/resources/hpxml-measures/.rubocop.yml
@@ -48,7 +48,8 @@ Style/DocumentationMethod:
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/HashSyntax:
-  Enabled: true
+  Enabled: false
+  EnforcedShorthandSyntax: never
 Style/Next:
   Enabled: true
 Style/NilComparison:


### PR DESCRIPTION
## Pull Request Description

Noticed this while working with @Sashadf1 on https://github.com/NREL/resstock/pull/1351.

Refactors the ResStockArgumentsPostHPXML measure to use the HPXML class rather than direct XML manipulation. Probably direct XML manipulation was used because it copied the approach used in the OS-HPXML BuildResidentialScheduleFile measure, but there's really no need for it. It's simpler/cleaner to use the HPXML class. (I'm refactoring the BuildResidentialScheduleFile measure [here](https://github.com/NREL/OpenStudio-HPXML/pull/1988) to also use the HPXML class.)

Note that I didn't do any testing beyond checking that the unit tests all pass. I assume that's sufficient?

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [x] `openstudio tasks.rb update_measures` has been run