### PR TITLE
Update sdr_upgrades_tmy3.yml

### DIFF
--- a/project_national/sdr_upgrades_tmy3.yml
+++ b/project_national/sdr_upgrades_tmy3.yml
@@ -96,6 +96,7 @@ workflow_generator:
       include_timeseries_emissions: true
       include_timeseries_emission_fuels: true
       include_timeseries_emission_end_uses: false
+      include_annual_emission_end_uses: false
       include_timeseries_hot_water_uses: true
       include_timeseries_total_loads: true
       include_timeseries_component_loads: true


### PR DESCRIPTION
Turn off end use emissions break down for annual results. We aren't publishing this. Follow up to https://github.com/NREL/resstock/pull/1371 where we turned these off for timeseries.

## Pull Request Description
We currently do not publish end-use emissions. We only publish totals and totals by fuel. In an effort to reduce the number of outputs, I am removing the end-use emissions. The end-use emissions can still be called out for testing purposes using

```
    simulation_output_report:
      include_annual_emission_end_uses: true
```

This flag is currently not available in BSB workflow generator and needs to be added.

### Related Pull Requests
https://github.com/NREL/resstock/pull/1371

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run