### PR TITLE
Add HTML comparison plots in the sdr-integration-tests job, follow-up

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -61,6 +61,18 @@ jobs:
         run: |
           rm -f Gemfile.lock && bundle install
 
+      - name: Install python
+        shell: bash
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt update
+          sudo -E apt-get install -y python3-pip
+
+      - name: Install python dependencies
+        run : |
+          python3 -m pip install --progress-bar off --upgrade pip
+          pip3 install --progress-bar off pandas pyyaml
+
       - name: Download formatted options_lookup
         uses: actions/download-artifact@v4
         with:
@@ -78,6 +90,17 @@ jobs:
       - name: Run all measure tests
         run: |
           bundle exec rake unit_tests:measure_tests
+
+      - name: Generate precomputed buildstocks
+        run: |
+          python3 test/update_yml_precomputed_files.py
+
+      - name: Upload precomputed buildstocks
+        uses: actions/upload-artifact@v4
+        with:
+          name: precomputed_buildstocks
+          path: test/tests_yml_files/yml_precomputed*/buildstock*.csv
+          if-no-files-found: error
 
       - name: Upload feature samples
         uses: actions/upload-artifact@v4
@@ -214,20 +237,15 @@ jobs:
           path: resources
           name: options_lookup
 
-      - name: Generate precomputed buildstocks
-        run: |
-          python3 test/update_yml_precomputed_files.py
+      - name: Download precomputed buildstocks
+        uses: actions/download-artifact@v4
+        with:
+          path: test/tests_yml_files
+          name: precomputed_buildstocks
 
       - name: Run run_analysis.rb
         run: |          
           bundle exec rake workflow:analysis_tests
-
-      - name: Upload precomputed buildstocks
-        uses: actions/upload-artifact@v4
-        with:
-          name: precomputed_buildstocks
-          path: test/tests_yml_files/yml_precomputed*/buildstock*.csv
-          if-no-files-found: error
 
       - name: Upload run_analysis.rb results
         uses: actions/upload-artifact@v4
@@ -690,12 +708,14 @@ jobs:
           fi
 
       - name: Download base results
+        if: github.event_name == 'pull_request'
         uses: actions/download-artifact@v4
         with:
           path: base_results
           name: base_results
 
       - name: Compare samples and results
+        if: github.event_name == 'pull_request'
         run: |          
           pip install numpy
           pip install pandas
@@ -711,6 +731,7 @@ jobs:
           python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -b base_results/upgrades/sdr_annual -f test/base_results/upgrades/sdr_annual -e test/base_results/sdr_comparisons/upgrades/sdr_annual # *.html
 
       - name: Upload comparisons
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sdr_comparisons

--- a/docs/technical_development_guide/source/advanced_tutorial/testing_infrastructure/index.rst
+++ b/docs/technical_development_guide/source/advanced_tutorial/testing_infrastructure/index.rst
@@ -120,8 +120,9 @@ Executes:
 
 Artifacts uploaded:
 
-- coverage
+- precomputed_buildstocks
 - feature_samples
+- coverage
 
 .. note::
 
@@ -160,7 +161,6 @@ Uses ``project_testing/testing_baseline.yml`` and ``project_national/national_ba
 
 Artifacts uploaded:
 
-- precomputed_buildstocks
 - run_analysis_results_csvs
 
 .. note::
@@ -296,10 +296,10 @@ Artifacts Produced
 Artifacts produced if tests are successful:
 
 - options_lookup: A sorted and formatted version of ``options_lookup.tsv`` that allows diffs to easily be seen.
-- coverage: Coverage logs.
-- feature_samples: The samples simulated in the feature branch for the analysis and integration tests.
-- documentation: A current version of the ResStock documentation in Read-the-Docs and the Technical Reference Guide PDF.
 - precomputed_buildstocks: Precomputed `buildstock.csv` for ``test/test_yml_files``.
+- feature_samples: The samples simulated in the feature branch for the analysis and integration tests.
+- coverage: Coverage logs.
+- documentation: A current version of the ResStock documentation in Read-the-Docs and the Technical Reference Guide PDF.
 - run_analysis_results_csvs: Annual results from the analysis tests.
 - base_results: Baseline and upgrades results stored on the base branch.
 - buildstockbatch_results_csvs: Annual results from the integration tests.


### PR DESCRIPTION
## Pull Request Description
Follow up on https://github.com/NREL/resstock/pull/1461.

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run