### PR TITLE
Add HTML comparison plots in the sdr-integration-tests job, follow-up 2

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -315,7 +315,6 @@ jobs:
 
       - name: Process results
         run: |
-          pip install plotly
           python test/process_bsb_analysis.py
 
       - name: Upload buildstockbatch results
@@ -408,7 +407,7 @@ jobs:
           python test/compare.py -a samples -b base_results/baseline/annual -f samples -e test/base_results/comparisons/baseline/annual # base_samples.csv, feature_samples.csv
           python test/compare.py -a results -b base_results/baseline/annual -f baseline/annual -e test/base_results/comparisons/baseline/annual # results_characteristics.csv, results_output.csv
           python test/compare.py -a results -af sum -ac build_existing_model.geometry_building_type_recs -x results_output_building_type_sum.csv -b base_results/baseline/annual -f baseline/annual -e test/base_results/comparisons/baseline/annual # results_output_building_type_sum.csv
-          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -x results_output_building_type.html -b base_results/baseline/annual -f baseline/annual -e test/base_results/comparisons/baseline/annual # *.html
+          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -b base_results/baseline/annual -f baseline/annual -e test/base_results/comparisons/baseline/annual # *.html
           
           # baseline timeseries
           mkdir test/base_results/comparisons/baseline/timeseries
@@ -714,6 +713,10 @@ jobs:
           path: base_results
           name: base_results
 
+      - name: Process results
+        run: |
+          python test/process_sdr_analysis.py
+
       - name: Compare samples and results
         if: github.event_name == 'pull_request'
         run: |          
@@ -723,12 +726,12 @@ jobs:
           pip install kaleido
           
           # results_characteristics.csv
-          python test/base_results/upgrades/create_results_characteristics.py -f base_results/upgrades/sdr_annual/results_up00.csv
-          python test/base_results/upgrades/create_results_characteristics.py -f test/base_results/upgrades/sdr_annual/results_up00.csv
+          python test/base_results/upgrades/create_results_characteristics.py -f base_results/upgrades/sdr_annual/combined/results.csv
+          python test/base_results/upgrades/create_results_characteristics.py -f test/base_results/upgrades/sdr_annual/combined/results.csv
           
           # upgrades annual
           mkdir -p test/base_results/sdr_comparisons/upgrades/sdr_annual
-          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -b base_results/upgrades/sdr_annual -f test/base_results/upgrades/sdr_annual -e test/base_results/sdr_comparisons/upgrades/sdr_annual # *.html
+          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -b base_results/upgrades/sdr_annual/combined -f test/base_results/upgrades/sdr_annual/combined -e test/base_results/sdr_comparisons/upgrades/sdr_annual # *.html
 
       - name: Upload comparisons
         if: github.event_name == 'pull_request'

--- a/resources/hpxml-measures/workflow/tests/compare.py
+++ b/resources/hpxml-measures/workflow/tests/compare.py
@@ -135,7 +135,7 @@ class BaseCompare:
 
     def visualize(self, aggregate_column=None, aggregate_function=None, display_column=None,
                   excludes=[], enum_maps={}, cols_to_ignore=[]):
-        colors = px.colors.qualitative.Dark24
+        colors = px.colors.qualitative.Dark24 * 2
 
         aggregate_columns = []
         if aggregate_column:

--- a/test/compare.py
+++ b/test/compare.py
@@ -304,9 +304,22 @@ if __name__ == '__main__':
         # this corresponds to diffs of results_upXX.csv files at
         # test/base_results/upgrades/sdr_annual in the sdr-integration-tests job
         # (i.e., sdr_upgrades_tmy3.yml annual upgrade results)
-        cols_to_ignore = ['applicability', 'upgrade', 'weight', 'in.']
-        compare = MoreCompare(args.base_folder, args.feature_folder, args.export_folder, None, args.map_file)
-        compare.visualize(args.aggregate_column, args.aggregate_function, args.display_column, excludes, enum_maps, cols_to_ignore)
+        categories = ['in.',
+                      'out.params',
+                      'out.electricity',
+                      'out.fuel_oil',
+                      'out.natural_gas',
+                      'out.propane',
+                      'out.site_energy',
+                      'out.hot_water',
+                      'out.capacity',
+                      'out.load',
+                      'out.unmet_hours',
+                      'out.emissions',
+                      'out.bills',
+                      'out.panel',
+                      'out.component_load',
+                      'out.energy_burden']
       else:
         # this corresponds to diffs of results_output.csv file columns at
         # test/base_results/baseline/annual in the integration-tests job
@@ -350,12 +363,13 @@ if __name__ == '__main__':
                       '.bills_3',
                       'upgrade_costs.',
                       'qoi_report.']
-        for category in categories:
-          export_file, ext = args.export_file.split('.')
-          export_file = '{}_{}.{}'.format(export_file, category.strip('.').rstrip('_'), ext)
-          cols_to_ignore = ['color_index'] + categories
-          cols_to_ignore.remove(category)
-          compare = MoreCompare(args.base_folder, args.feature_folder, args.export_folder, export_file, args.map_file)
-          compare.visualize(args.aggregate_column, args.aggregate_function, args.display_column, excludes, enum_maps, cols_to_ignore)
+      for category in categories:
+        if category == 'in.':
+            continue
+        export_file = '{}.html'.format(category.strip('.').rstrip('_'))
+        cols_to_ignore = ['color_index'] + categories
+        cols_to_ignore.remove(category)
+        compare = MoreCompare(args.base_folder, args.feature_folder, args.export_folder, export_file, args.map_file)
+        compare.visualize(args.aggregate_column, args.aggregate_function, args.display_column, excludes, enum_maps, cols_to_ignore)
     elif action == 'timeseries':
       compare.timeseries()

--- a/test/process_sdr_analysis.py
+++ b/test/process_sdr_analysis.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pandas as pd
+from functools import reduce
+import csv
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.abspath(__file__), '../../resources/hpxml-measures/workflow/tests')))
+from compare import read_csv
+import glob
+
+
+if __name__ == '__main__':
+
+    col_exclusions = ['applicability',
+                      'weight',
+                      'upgrade_name',
+                      'upgrade.']
+
+    folders = ['base_results/upgrades/sdr_annual', 'test/base_results/upgrades/sdr_annual']
+
+    for folder in folders:
+
+        outdir = os.path.join(folder, 'combined')
+        if not os.path.exists(outdir):
+          os.makedirs(outdir)
+
+        dfs = []
+        results_csvs = sorted(glob.glob(os.path.join(folder, '*.csv')))
+        for results_csv in results_csvs:
+            df = read_csv(results_csv)
+            _, upg_ext = os.path.basename(results_csv).split('_')
+            upg, _ = upg_ext.split('.')
+            df['bldg_id'] = df['bldg_id'].apply(lambda x: '{}-{}'.format(upg, x))
+            dfs.append(df)
+        df = pd.concat(dfs)
+        df = df.set_index('bldg_id')
+        
+        col_inclusions = []
+        for col in df.columns.values:
+            if any([col_exclusion in col for col_exclusion in col_exclusions]):
+                continue
+            col_inclusions.append(col)
+        df = df[col_inclusions]
+
+        df = df.rename(columns={'upgrade': 'color_index'})
+
+        df.to_csv(os.path.join(outdir, 'results.csv'))


### PR DESCRIPTION
## Pull Request Description
Follow up on https://github.com/NREL/resstock/pull/1461. Again.
Closes #1416.

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run