### PR TITLE
Fix latex docker image version to 2024 for TRD

### DIFF
--- a/docs/technical_reference_guide/README.md
+++ b/docs/technical_reference_guide/README.md
@@ -17,16 +17,16 @@ Docker can be used to compile the ResStock Technical Reference Guide locally. Fi
 cd <RESSTOCK_DIR>/docs/technical_reference_guide
 ```
 
-2. Pull a docker container with the full version of textlive (this might take several minutes, but only needs to be done once. If you have issues, get off the VPN during the pull)
+2. Pull a docker container with the full version of textlive (this might take several minutes, but only needs to be done once. If you have issues, get off the VPN during the pull) Note: 2025 docker image had formatting issue so let's use 2024 until the latest does not have this issue.
 
 ```
-$ docker pull mfisherman/texlive-full
+$ docker pull mfisherman/texlive-full:2024
 ```
 
 3. Run the container and mount the current directory contents in the workspace directory of the container. Use /bin/bash as the default shell. (For Windows, use ```docker run --rm -it -v "%CD%":/data mfisherman/texlive-full:latest```.)
 
 ```
-docker run --rm -it -v $(pwd):/workspace mfisherman/texlive-full /bin/bash
+docker run --rm -it -v $(pwd):/workspace mfisherman/texlive-full:2024 /bin/bash
 ```
 
 4. The container should start running immediately. Once in the container, your CLI looks something like this: `19603f1794b0:/data#`, with `19603f1794b0` likely being different. Go to the workspace folder where the Technical Reference Guide directory is located. (For Windows, the current directory contents have been mounted to the data folder.)


### PR DESCRIPTION
## Pull Request Description
Weird formatting issue with overlapping text from 2025.2 (latest) docker image release for [fishermen/textlive-full](https://hub.docker.com/r/mfisherman/texlive-full).

For now, hard-setting instruction to pull 2024 version only for local build for Mac users.

Filed issue with textlive-full about this: https://github.com/mfisherman/docker/issues/4

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run