### PR TITLE
Skip full plot generation in CI workflow

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -806,10 +806,11 @@ jobs:
         run: |
           uv run python resstockpostproc/upgrade_comparison/main.py --quantity_group="Unmet HVAC Hours"
 
-      - name: Generate rest of the plots
-        working-directory: postprocessing
-        run: |
-          uv run python resstockpostproc/upgrade_comparison/main.py
+      # Takes 4 hours+ in CI - skip until more efficient method is found.
+      # - name: Generate rest of the plots
+      #   working-directory: postprocessing
+      #   run: |
+      #     uv run python resstockpostproc/upgrade_comparison/main.py
 
       - name: Upload plots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Comment out the full plot generation step to improve CI efficiency. We are still generating the full plot matrix for one set of columns (unmet hours) - this will skip doing it for every combination of output columns specified in the yaml.

## Pull Request Description
[description here]

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
[What issue(s) is the PR addressing]

## Checklist

#### Required:
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/blob/develop/docs/technical_development_guide/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)
- [ ] Update documentation (one is required)
     - [ ] [Technical reference guide](https://github.com/NREL/resstock/tree/develop/docs/technical_reference_guide)
     - [ ] [Technical development guide](https://github.com/NREL/resstock/tree/develop/docs/technical_development_guide)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run