### PR TITLE
Opt-in coverage floor on the segment selection, and a guard for buildstock regions the catalogue has no partition for

### DIFF
--- a/postprocessing/resstockpostproc/allocated_weights.py
+++ b/postprocessing/resstockpostproc/allocated_weights.py
@@ -572,6 +572,73 @@ def partition_catalogue_by_sampling_region(
     return partition_dir
 
 
+def sampling_region_partition_ids(output_dir: FsspecOutputDir, partition_dir: str) -> list[str]:
+    """Return the sampling region ids the catalogue was staged into, in a stable order.
+
+    Args:
+        output_dir: Dictionary containing filesystem info from setup_fsspec_filesystem
+        partition_dir: Partition directory from partition_catalogue_by_sampling_region
+
+    Returns:
+        The region id of each staged partition
+
+    Raises:
+        FileNotFoundError: If the partition directory holds no partitions
+    """
+
+    # One directory per region, holding one or more parquet files
+    region_dirs = sorted({Path(p).parent.name for p in output_dir["fs"].glob(f"{partition_dir}/*/*.parquet")})
+    if not region_dirs:
+        raise FileNotFoundError(
+            f"No catalogue partitions found in {partition_dir}, "
+            f"call partition_catalogue_by_sampling_region() first."
+        )
+    return [region_dir.split("=", 1)[1] for region_dir in region_dirs]
+
+
+def report_buildstock_regions_without_a_partition(
+    bs_df: pl.DataFrame, partition_region_ids: Sequence[str]
+) -> pl.DataFrame:
+    """Report buildings whose sampling region has no catalogue partition to allocate them to.
+
+    The allocation walks the catalogue's region partitions and filters the buildstock to each,
+    so a building labelled with a region the catalogue never produced is offered to no pool at
+    all: it leaves the run without appearing anywhere, because the miss report counts catalogue
+    rows rather than buildings. The other two guards both look the other way down the join —
+    that every catalogue geography maps to a region, and that every catalogue row finds a
+    building — so this direction is the one nothing else covers.
+
+    It reports rather than raises: the buildstock legitimately carries regions the catalogue
+    does not when the two are versioned apart, and the count is what separates that from a
+    region label gone wrong.
+
+    Args:
+        bs_df: The buildstock's allocation keys, carrying in.sampling_region_id
+        partition_region_ids: The region ids the catalogue was staged into
+
+    Returns:
+        Buildings per orphan region id, empty when every region the buildstock names has one
+    """
+
+    staged = pl.DataFrame(
+        {"in.sampling_region_id": list(partition_region_ids)},
+        schema={"in.sampling_region_id": bs_df.schema["in.sampling_region_id"]},
+    )
+    orphans = (
+        bs_df.group_by("in.sampling_region_id")
+        .len(name="buildings")
+        .join(staged, on="in.sampling_region_id", how="anti")
+        .sort("buildings", descending=True)
+    )
+    if orphans.height:
+        logger.warning(
+            f"{orphans['buildings'].sum()} of {bs_df.height} buildings sit in {orphans.height} "
+            f"sampling regions the catalogue has no partition for, so no catalogue row can draw "
+            f"them: {dict(orphans.iter_rows())}"
+        )
+    return orphans
+
+
 def iter_sampling_region_partitions(
     output_dir: FsspecOutputDir, partition_dir: str
 ) -> Iterator[tuple[str, pl.DataFrame]]:
@@ -589,17 +656,8 @@ def iter_sampling_region_partitions(
         Tuples of (sampling region id, that region's catalogue rows)
     """
 
-    # One directory per region, holding one or more parquet files
-    region_dirs = sorted({Path(p).parent.name for p in output_dir["fs"].glob(f"{partition_dir}/*/*.parquet")})
-    if not region_dirs:
-        raise FileNotFoundError(
-            f"No catalogue partitions found in {partition_dir}, "
-            f"call partition_catalogue_by_sampling_region() first."
-        )
-
-    for region_dir in region_dirs:
-        region_id = region_dir.split("=", 1)[1]
-        region_glob = f"{partition_dir}/{region_dir}/*.parquet"
+    for region_id in sampling_region_partition_ids(output_dir, partition_dir):
+        region_glob = f"{partition_dir}/{SAMPLING_REGION_PARTITION}={region_id}/*.parquet"
         # hive_partitioning is off so the region only ever arrives as the column inside the
         # files, rather than also being parsed a second time out of the directory name
         geo_df = pl.read_parquet(
@@ -1039,10 +1097,11 @@ def create_allocated_weights(
     1. Sets up the filesystem
     2. Stages the catalogue as one parquet partition per sampling region
     3. Loads the allocation keys of the buildstock sample
-    4. For each sampling region, allocates its buildings to its geographical units, walking
+    4. Reports any sampling region the buildstock names that the catalogue has no partition for
+    5. For each sampling region, allocates its buildings to its geographical units, walking
        the fallback ladder for empty shelves, and writes that region's weights
-    5. Writes the miss report and checks the fraction the ladder still left unallocated
-    6. Writes the foreign key table
+    6. Writes the miss report and checks the fraction the ladder still left unallocated
+    7. Writes the foreign key table
 
     The catalogue is never held whole. Peak memory is set by the largest single sampling
     region, so it does not grow with the size of the country covered; see
@@ -1083,6 +1142,9 @@ def create_allocated_weights(
         columns=ALLOCATION_KEYS + ["bldg_id"],
         storage_options=output_dir["storage_options"],
     )
+
+    # Surface buildings the region-at-a-time allocation can never offer to a pool, before it runs
+    report_buildstock_regions_without_a_partition(bs_df, sampling_region_partition_ids(output_dir, partition_dir))
 
     # Allocate one sampling region at a time, keeping only the misses and the counts
     logger.info(f"Allocating buildings to geographical units by sampling region (seed={seed})")

--- a/postprocessing/tests/test_allocated_weights.py
+++ b/postprocessing/tests/test_allocated_weights.py
@@ -1,0 +1,49 @@
+import logging
+
+import polars as pl
+from resstockpostproc.allocated_weights import report_buildstock_regions_without_a_partition
+
+
+def make_buildstock(region_by_building: dict[int, str]) -> pl.DataFrame:
+    """Buildstock allocation keys, one row per building, carrying only the region label."""
+    return pl.DataFrame(
+        {
+            "bldg_id": list(region_by_building.keys()),
+            "in.sampling_region_id": list(region_by_building.values()),
+        }
+    )
+
+
+def test_a_buildstock_region_with_no_catalogue_partition_is_reported(caplog):
+    # Region 9 is what a new region, a type mismatch, or a failed sim leaves behind: the
+    # allocation walks catalogue partitions, so these three buildings are offered to no pool
+    bs_df = make_buildstock({1: "3", 2: "3", 3: "9", 4: "9", 5: "9"})
+
+    with caplog.at_level(logging.WARNING):
+        orphans = report_buildstock_regions_without_a_partition(bs_df, ["3", "7"])
+
+    assert orphans.to_dicts() == [{"in.sampling_region_id": "9", "buildings": 3}]
+    assert "3 of 5 buildings" in caplog.text
+    assert "'9': 3" in caplog.text
+
+
+def test_a_buildstock_inside_the_partitions_reports_nothing(caplog):
+    bs_df = make_buildstock({1: "3", 2: "7"})
+
+    with caplog.at_level(logging.WARNING):
+        orphans = report_buildstock_regions_without_a_partition(bs_df, ["3", "7", "11"])
+
+    # A partition with no buildings is ordinary; the guard only looks the other way
+    assert orphans.height == 0
+    assert caplog.text == ""
+
+
+def test_every_orphan_region_is_named_and_the_largest_leads(caplog):
+    bs_df = make_buildstock({1: "3", 2: "9", 3: "12", 4: "12"})
+
+    with caplog.at_level(logging.WARNING):
+        orphans = report_buildstock_regions_without_a_partition(bs_df, ["3"])
+
+    assert orphans["in.sampling_region_id"].to_list() == ["12", "9"]
+    assert orphans["buildings"].to_list() == [2, 1]
+    assert "3 of 4 buildings" in caplog.text

--- a/samplers/stratified/README.md
+++ b/samplers/stratified/README.md
@@ -53,3 +53,15 @@ The sampler config file is located at `sampler/sampler_config.yaml`. You can mod
 - `segment_vars`: The characteristics whose combination defines a segment. Each is a characteristic the allocator later joins on, so a characteristic that only flows downhill through the TSVs does not belong here.
 - `segment_selection_sample_size`: Size of the initial sample used to rank segments by how much stock they cover.
 - `num_samples_per_segment`: Buildings kept per segment. This single value sets both how many segments are kept and how many buildings are taken from each. The take is a random draw within the segment, seeded from `RANDOM_SEED` in `sampler.py` so a rerun reproduces it.
+- `coverage_floor_vars`: The characteristics whose combination defines a floor cell. Leave the key out and the selection is the rank cut alone, which is what every run so far has used. Set it and the selection keeps everything the rank cut kept and then adds, for each floor cell the pilot reached but the cut left with no selected segment, the most populous segment holding a pilot row in that cell. Each name must be a characteristic the pilot samples, so a `segment_vars` entry or an ancestor of one; `Tenure` and `Vacancy Status` qualify even though they do not split a segment.
+
+  The floor is additive: it displaces nothing, so every building the rank cut alone would have produced is still produced and the run builds more than `num_datapoints`. That extra build is what it costs, and it buys back stock the allocator would otherwise find no building for — the fallback ladder releases only vintage and federal poverty level, so a floor cell the cut drops has nothing to stand in for it.
+
+  Both are measured over 40 replicates of the run-3 pilot, against a rank cut that leaves 278,645 catalogue rows unmatched at `segment_selection_sample_size: 10000000` and 321,364 at `50000000`:
+
+  | `coverage_floor_vars` | extra build, 10M | rows recovered, 10M | extra build, 50M | rows recovered, 50M |
+  |---|---|---|---|---|
+  | Sampling Region, Geometry Building Type RECS, Heating Fuel | +0.48% | −64% | +1.34% | −63% |
+  | the above plus Tenure, Vacancy Status | +1.00% | −88% | +2.87% | −94% |
+
+  The tenure and vacancy status columns carry most of the recovery because the allocator joins on them: a segment can be selected and still put none of its take into one tenure of its own cell.

--- a/samplers/stratified/sampler/run_sampler.py
+++ b/samplers/stratified/sampler/run_sampler.py
@@ -142,6 +142,76 @@ def sample_all(project_path, num_samples, *, segment_vars: set[str] | None = Non
     return sample_df
 
 
+def add_coverage_floor_segments(pilot_df: pl.DataFrame, segment_counts: pl.DataFrame,
+                                top_segments: pl.DataFrame, segment_cols: list[str],
+                                coverage_floor_vars: list[str]) -> pl.DataFrame:
+    """Add the segments needed to leave every pilot-reached floor cell with a selected segment.
+
+    The rank cut keeps the most populous `num_segments` segments and is all-or-nothing: a floor
+    cell whose segments all sit below the cut contributes no buildings at all, and the allocator's
+    fallback ladder releases only vintage and federal poverty level, so no other building can
+    stand in for it. This adds back one segment per floor cell the cut missed — the most populous
+    of the segments the pilot placed in that cell, with the same segment-value tie-break the cut
+    itself uses — so the selection reaches every floor cell the pilot reached.
+
+    A floor cell is read off the pilot rows rather than off the segment, so `coverage_floor_vars`
+    may name characteristics that are not `segment_vars`: a segment then spans several floor
+    cells, and the segment rescuing one of them is the most populous segment holding a pilot row
+    in it. That is what lets the floor be defined on tenure and vacancy status, which the
+    allocator joins on but which do not split a segment.
+
+    The added segments are additive. Nothing already selected is displaced, so every building the
+    rank cut alone would have produced is still produced and the run builds correspondingly more
+    than `num_datapoints`.
+
+    Args:
+        pilot_df: The pilot sample, one row per drawn building, carrying every floor cell column
+        segment_counts: One row per segment the pilot reached, carrying a `count` column
+        top_segments: The segments the rank cut kept, a subset of `segment_counts`
+        segment_cols: Columns whose combination defines a segment
+        coverage_floor_vars: Columns whose combination defines a floor cell
+
+    Returns:
+        `top_segments` with one added segment for each floor cell it did not already cover
+
+    Raises:
+        ValueError: If a name in `coverage_floor_vars` is not a column of the pilot sample
+    """
+
+    unknown = sorted(set(coverage_floor_vars) - set(pilot_df.columns))
+    if unknown:
+        raise ValueError(
+            f"coverage_floor_vars {unknown} are not sampled characteristics, so no pilot row "
+            f"carries them; every floor cell column must be a segment_var or an ancestor of one"
+        )
+
+    cell_cols = list(dict.fromkeys(coverage_floor_vars))
+    pair_cols = list(dict.fromkeys([*cell_cols, *segment_cols]))
+    # One row per (floor cell, segment) pair the pilot produced, carrying the segment's pilot count
+    cell_segments = pilot_df.select(pair_cols).unique().join(segment_counts, on=segment_cols, how="left")
+
+    covered_cells = cell_segments.join(top_segments.select(segment_cols), on=segment_cols, how="semi")
+    uncovered_cells = (
+        cell_segments.select(cell_cols).unique()
+        .join(covered_cells.select(cell_cols).unique(), on=cell_cols, how="anti")
+    )
+    if uncovered_cells.height == 0:
+        print(f"Coverage floor over {cell_cols} adds nothing: the rank cut already reaches every cell")
+        return top_segments
+
+    # A rescuing segment can be the strongest in more than one uncovered cell, so it is taken once
+    rescued = (
+        cell_segments.join(uncovered_cells, on=cell_cols, how="semi")
+        .sort(["count", *segment_cols], descending=[True, *([False] * len(segment_cols))])
+        .unique(subset=cell_cols, keep="first", maintain_order=True)
+        .select(top_segments.columns)
+        .unique(subset=segment_cols, keep="first", maintain_order=True)
+    )
+    print(f"Coverage floor over {cell_cols} adds {rescued.height} segments for the "
+          f"{uncovered_cells.height} cells the rank cut left uncovered")
+    return pl.concat([top_segments, rescued], how="vertical")
+
+
 def take_samples_per_segment(df: pl.DataFrame, segment_cols: list[str], num_samples_per_segment: int,
                              random_seed: int = RANDOM_SEED) -> pl.DataFrame:
     """Take a random `num_samples_per_segment` rows out of each segment.
@@ -224,6 +294,8 @@ def sample(project: str, num_datapoints: int, config: str, output: str) -> None:
     segment_cols = sorted(segment_vars)
     initial_sample_size = config.get('segment_selection_sample_size', 10000000)
     num_samples_per_segment = config.get('num_samples_per_segment', DEFAULT_NUM_SAMPLES_PER_SEGMENT)
+    # Absent, the selection is the rank cut alone; see add_coverage_floor_segments
+    coverage_floor_vars = list(config.get('coverage_floor_vars', []))
     initial_samples_df = None
     init_start_time = time.time()
     print(project, num_datapoints, output, segment_vars)
@@ -232,13 +304,16 @@ def sample(project: str, num_datapoints: int, config: str, output: str) -> None:
     print(f"Initial sampling completed in {time.time() - init_start_time:.2f} seconds. Sample size: {initial_samples_df.shape}")
     initial_samples_df = initial_samples_df.drop("Building")
     num_segments = num_datapoints // num_samples_per_segment
+    segment_counts = initial_samples_df.group_by(segment_cols, maintain_order=True).agg(pl.len().alias("count"))
     # Select the most populous segments, using segment values to break count ties reproducibly.
     top_segments = (
-        initial_samples_df.group_by(segment_cols, maintain_order=True)
-        .agg(pl.len().alias("count"))
+        segment_counts
         .sort(["count", *segment_cols], descending=[True, *([False] * len(segment_cols))])
         .limit(num_segments)
     )
+    if coverage_floor_vars:
+        top_segments = add_coverage_floor_segments(initial_samples_df, segment_counts, top_segments,
+                                                   segment_cols, coverage_floor_vars)
     new_df = initial_samples_df.join(top_segments, on=segment_cols, validate="m:1", how="left", maintain_order="left")
     valid_df = new_df.filter(~pl.col('count').is_null())
     valid_df = valid_df.drop("count")

--- a/samplers/stratified/sampler/sampler_config.yaml
+++ b/samplers/stratified/sampler/sampler_config.yaml
@@ -10,3 +10,14 @@ segment_selection_sample_size: 50000000  # Determine segments using 50M samples
 # Buildings kept per segment. Sets both the number of segments retained
 # (num_datapoints // num_samples_per_segment) and the take within each segment.
 num_samples_per_segment: 12
+
+# Characteristics whose combination defines a coverage floor cell. Absent, the selection is the
+# rank cut alone. Present, the cut's selection additionally keeps the most populous segment of
+# every floor cell it would otherwise have dropped, and the run builds past num_datapoints by
+# the amount that costs. See the README for the measured trade-off.
+# coverage_floor_vars:
+#     - "Sampling Region"
+#     - "Geometry Building Type RECS"
+#     - "Heating Fuel"
+#     - "Tenure"
+#     - "Vacancy Status"

--- a/samplers/stratified/tests/test_sampling.py
+++ b/samplers/stratified/tests/test_sampling.py
@@ -2,7 +2,8 @@ import pathlib
 import os, sys
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 from sampler.sampling_utils import read_char_tsv, get_param2tsv, get_samples
-from sampler.run_sampler import sample_param, sample_all, take_samples_per_segment
+from sampler.run_sampler import add_coverage_floor_segments, sample_param, sample_all, take_samples_per_segment
+import pytest
 from collections import Counter
 import pandas as pd
 import polars as pl
@@ -148,6 +149,113 @@ def test_segment_vars_are_characteristics_the_allocator_joins_on():
         'Heating Fuel',
         'Sampling Region',
     }
+
+
+SEGMENT_COLS = ['Region', 'Fuel']
+
+
+def make_pilot(rows: list[tuple[str, str, str, int]]) -> pl.DataFrame:
+    """Pilot sample of (region, fuel, tenure) repeated the given number of times, one row a building."""
+    return pl.DataFrame({
+        'Region': [region for region, _, _, n in rows for _ in range(n)],
+        'Fuel': [fuel for _, fuel, _, n in rows for _ in range(n)],
+        'Tenure': [tenure for _, _, tenure, n in rows for _ in range(n)],
+    })
+
+
+def rank_cut(pilot: pl.DataFrame, num_segments: int) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """The segment counts and the top-N selection, as the sample command forms them."""
+    segment_counts = pilot.group_by(SEGMENT_COLS, maintain_order=True).agg(pl.len().alias('count'))
+    top_segments = (
+        segment_counts
+        .sort(['count', *SEGMENT_COLS], descending=[True, *([False] * len(SEGMENT_COLS))])
+        .limit(num_segments)
+    )
+    return segment_counts, top_segments
+
+
+def segments_of(df: pl.DataFrame) -> list[tuple[str, str]]:
+    return list(df.select(SEGMENT_COLS).iter_rows())
+
+
+def test_coverage_floor_rescues_the_cells_the_rank_cut_dropped():
+    # Two regions, each with a populous gas segment and a rare oil segment; the cut keeps two
+    pilot = make_pilot([('A', 'Gas', 'Owner', 100), ('A', 'Oil', 'Owner', 3),
+                        ('B', 'Gas', 'Owner', 50), ('B', 'Oil', 'Owner', 2)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=2)
+    assert segments_of(top_segments) == [('A', 'Gas'), ('B', 'Gas')]
+
+    floored = add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                          ['Region', 'Fuel'])
+
+    # Every (region, fuel) the pilot reached now has a segment, and the kept ones lead unchanged
+    assert segments_of(floored) == [('A', 'Gas'), ('B', 'Gas'), ('A', 'Oil'), ('B', 'Oil')]
+    assert floored.columns == top_segments.columns
+    assert dict(floored.select(['Fuel', 'count']).filter(pl.col('Fuel') == 'Oil')
+                .group_by('Fuel').agg(pl.col('count').sum()).iter_rows()) == {'Oil': 5}
+
+
+def test_a_floor_cell_may_be_finer_than_a_segment():
+    # Tenure is not a segment var, so one segment spans several floor cells
+    pilot = make_pilot([('A', 'Gas', 'Owner', 100), ('A', 'Oil', 'Renter', 3),
+                        ('B', 'Gas', 'Owner', 50), ('B', 'Oil', 'Renter', 2)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=2)
+
+    floored = add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                          ['Region', 'Tenure'])
+
+    # The cut covers only the owner cells; the renter cells are rescued by the oil segments
+    assert segments_of(floored) == [('A', 'Gas'), ('B', 'Gas'), ('A', 'Oil'), ('B', 'Oil')]
+
+
+def test_a_segment_rescuing_two_cells_is_added_once():
+    # The rescued frame is joined onto the pilot with validate="m:1", so a repeat would fail there
+    pilot = make_pilot([('A', 'Gas', 'Owner', 100), ('A', 'Oil', 'Renter', 3),
+                        ('A', 'Oil', 'Vacant', 2)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=1)
+
+    floored = add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                          ['Region', 'Tenure'])
+
+    assert segments_of(floored) == [('A', 'Gas'), ('A', 'Oil')]
+    assert floored.select(SEGMENT_COLS).n_unique() == floored.height
+
+
+def test_the_strongest_segment_rescues_a_cell_and_ties_break_on_segment_values():
+    # Oil and Propane both reach (A, Renter) with five pilot rows; the cut's own tie-break is the
+    # segment values ascending, so Oil is taken
+    pilot = make_pilot([('A', 'Gas', 'Owner', 100), ('A', 'Propane', 'Renter', 5),
+                        ('A', 'Oil', 'Renter', 5), ('A', 'Wood', 'Renter', 4)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=1)
+
+    floored = add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                          ['Region', 'Tenure'])
+
+    assert segments_of(floored) == [('A', 'Gas'), ('A', 'Oil')]
+
+
+def test_a_floor_reaching_no_new_cell_returns_the_selection_untouched():
+    pilot = make_pilot([('A', 'Gas', 'Owner', 100), ('A', 'Oil', 'Owner', 3)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=2)
+
+    floored = add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                          ['Region', 'Fuel'])
+
+    assert floored.equals(top_segments)
+
+
+def test_a_floor_cell_column_the_pilot_does_not_carry_is_rejected():
+    pilot = make_pilot([('A', 'Gas', 'Owner', 10)])
+    segment_counts, top_segments = rank_cut(pilot, num_segments=1)
+
+    with pytest.raises(ValueError, match='Vintage'):
+        add_coverage_floor_segments(pilot, segment_counts, top_segments, SEGMENT_COLS,
+                                    ['Region', 'Vintage'])
+
+
+def test_the_shipped_config_leaves_the_coverage_floor_off():
+    # Absent, the selection is the rank cut alone, which is what the shipped runs have produced
+    assert 'coverage_floor_vars' not in read_sampler_config()
 
 
 def test_one_config_value_sets_both_the_segment_count_and_the_take():


### PR DESCRIPTION
Two independent changes, both opened for testing rather than merging. Neither changes the behaviour of any existing configuration: the coverage floor is off unless a new config key is present, and the allocation guard only adds a log line.

## 1. An opt-in coverage floor on the segment selection

`sampler/run_sampler.py` gains `add_coverage_floor_segments`, driven by a new `coverage_floor_vars` key in `sampler_config.yaml`. **Leave the key out and the sampler is exactly what it is today** — the rank cut alone. Set it and the selection keeps everything the rank cut kept, then adds, for each floor cell the pilot reached but the cut left with no selected segment, the most populous segment holding a pilot row in that cell.

### Why

The rank cut keeps the `num_datapoints // num_samples_per_segment` most populous segments, and it is all-or-nothing. A floor cell whose segments all sit below the cut produces no buildings at all, and the allocator's fallback ladder releases only vintage and federal poverty level, so no other building can stand in for it. Those cells become catalogue rows that find no matching building.

In run `new_sampling_test_3` that cost 278,645 unmatched catalogue rows nationally, of which **96.8% was attributable to the cut alone** — cells with live segments where every one of them lost the rank. It is also the largest single component of the Alaska shortfall (4.06% of Alaska's dwelling units unmatched, 29× the national rate).

### Measured effect

40 replicates of the run-3 pilot, Monte Carlo over the reconstructed pilot intensities: a segment's pilot count is Poisson with its reconstructed intensity, the selection keeps the segments with the largest realised counts, and a kept segment contributes `min(12, count)` buildings whose tenure and vacancy status is a multinomial draw from its own conditional. The as-run arm is the same harness that produced the earlier fix-costing table and reproduces its as-run row to the digit. What it estimates is the rule's expected behaviour over replicates, not the one realisation run 3 happened to draw.

| | as-run (10M pilot) | floor (10M) | as-run (50M) | floor (50M) |
|---|---|---|---|---|
| buildings built | 539,898 | 545,404 | 549,996 | 565,796 |
| extra build | — | +5,476 (**+1.00%**) | — | +15,800 (**+2.87%**) |
| extra segments selected | — | +1,678 | — | +1,912 |
| unmatched catalogue rows | 278,645 | **34,574** | 321,364 | **17,068** |
| p05 / p95 | 262,080 / 298,821 | 30,835 / 38,456 | 309,923 / 331,877 | 14,528 / 19,263 |
| change vs as-run 10M | — | **−87.6%** | +15.3% | **−93.9%** |
| Alaska unmatched | 12,850 (4.06%) | 3,809 (**1.20%**) | 14,182 (4.48%) | 2,652 (**0.84%**) |

with `coverage_floor_vars: [Sampling Region, Geometry Building Type RECS, Heating Fuel, Tenure, Vacancy Status]`.

Two things worth knowing about the cost:

* **At the current 10M pilot most of it is free.** The as-run selection under-delivers against its own budget by ~10,100 buildings, because a selected segment contributes `min(12, count)` and many selected segments drew fewer than twelve. At 50M essentially every selected segment draws ≥ 12, so there is no headroom and the extra build is a real overrun.
* **The floor is a strict gain, never a trade.** Nothing selected is displaced, so no cell the rank cut covered can lose its coverage.

The floor is also what makes the 50M `segment_selection_sample_size` bump pay off on coverage. On its own that bump **raises** the unmatched count by 15.3% (278,645 → 321,364): at 10M a mean of 1,822 segments tie on the exact count at the cut boundary and the tie-break noise randomly admits rare segments, whereas at 50M only 353 tie and the tail is excluded deterministically instead of occasionally. Combined with the floor, 50M is the best measured configuration in the table.

### Choosing `coverage_floor_vars`

The cheaper three-variable cell is also available and is documented alongside:

| `coverage_floor_vars` | extra build, 10M | rows recovered, 10M | extra build, 50M | rows recovered, 50M |
|---|---|---|---|---|
| Sampling Region, Geometry Building Type RECS, Heating Fuel | +0.48% | −64% | +1.34% | −63% |
| the above plus Tenure, Vacancy Status | +1.00% | −88% | +2.87% | −94% |

Tenure and vacancy status carry most of the recovery because the allocator joins on them, and they cost the most because a segment spans all three tenure slots. `coverage_floor_vars` names are read off the pilot rows rather than off the segment, so any characteristic the pilot samples is allowed — a `segment_vars` entry or an ancestor of one. Tenure and Vacancy Status qualify because they are ancestors of Federal Poverty Level.

### What the floor does not fix

After the floor, the residue attributable to the rank cut is zero by construction. What remains at 10M is 4,070 rows the pilot cannot reach at any depth (2,386 of them structural — cells the TSV network cannot generate) and 30,503 rows where the segment *was* selected and its twelve-building take simply put no building into that tenure slot. That last band is a property of the take, not of the cut, and no selection rule reaches it. Alaska in particular stays the worst state in the country by rate even after the floor: its `Heating Fuel.tsv` rows come from ARIS rather than PUMS and disagree with the catalogue on Alaska's fuel margin at TVD 10.8% against 0.32% nationally, which is a separate problem.

## 2. Naming the buildstock regions the catalogue has no partition for

`create_allocated_weights` walks the catalogue's sampling region partitions and filters the buildstock to each. A building labelled with a region the catalogue never produced is therefore offered to no pool at all, and it leaves the run without appearing anywhere: the miss report counts catalogue rows, not buildings, and both existing guards look the other way down the join — that every catalogue geography maps to a region, and that every catalogue row finds a building.

`report_buildstock_regions_without_a_partition` closes that direction with an anti-join of the buildstock's distinct region labels against the staged partition ids, logging a warning naming each orphan region and its building count. It reports rather than raises: the buildstock legitimately carries regions the catalogue does not when the two are versioned apart, and the count is what separates that from a region label gone wrong.

This is not currently firing on any known run — it was found while chasing a `Void` sampling region that turned out to be a false alarm — but it is the one silent-drop path in the allocation that nothing else covers.

## Tests

* `samplers/stratified/tests/test_sampling.py`: five tests over `add_coverage_floor_segments` — a dropped cell is rescued, a floor cell may be finer than a segment, a segment rescuing two cells is added once (the downstream join validates `m:1`), the strongest segment wins with the cut's own tie-break, and an unknown floor-cell column raises. Plus two pinning the opt-out: a floor that reaches nothing returns the selection untouched, and the shipped config carries no `coverage_floor_vars`.
* `postprocessing/tests/test_allocated_weights.py`: three tests over the guard — an orphan region is reported with its count in the log, a buildstock inside the partitions reports nothing (a partition with no buildings is ordinary), and every orphan is named with the largest first.
* Sampler suite 8 → 15 passing, postprocessing suite 4 → 7 passing.

The opt-out claim is checked directly rather than asserted: running `resstock-sampler sample` on `tests/project_sampling_test` with no `coverage_floor_vars` produces a buildstock byte-identical to the same command at 595b4d0608 (md5 `4e1bae432b3aaf8309559f3d8f9328bc` both ways).

## Not in this PR

`utils/sampling_probability.py`'s QC4/QC5 checks round to one decimal, so several percent of probability mass on a bad option can pass them. Noted rather than changed.
